### PR TITLE
Refactor: Decorators suggestion for class methods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# TCG_Sample
+- Turn based Card Game on Unreal Engine
+
+## Dependencies
+- Unreal Engine 5.5
+- clang(maybe)
+
+## Compile Tutorial
+- Idk
+
+# What I am doing to this
+With this pull request, I'd like to 
+
+## #define TMP_NAME
+> This is for convenience/safe.  
+> It will help making the shape of declaration and definition of class methods.  
+> Example would be following:
+
+```cpp
+#define TMP_NAME
+class A {
+    int TMP_NAMESPACE returns3(); // This is a function
+};
+#undef TMP_NAME
+
+// hint for telling following functions are methods.
+#define TMP_NAME A::
+
+// By the same shape, returns3 will be automatically searched.
+int TMP_NAME returns3() {
+    return 3;
+}
+```
+## Private/_imp.h
+> This is for convenience/safe.  
+> Including it will automatically disable the class method decorators which are not necessary for implementing methods,  
+> preventing the miscompile from using them.
+
+> Two keywords are disabled for now: 
+- virtual
+- override

--- a/Source/TCG_Sample/Private/CardBase.cpp
+++ b/Source/TCG_Sample/Private/CardBase.cpp
@@ -2,25 +2,29 @@
 
 
 #include "CardBase.h"
+#include "_imp.h"
 
+
+#define TMP_NAME ACardBase::
 
 // Sets default values
-ACardBase::ACardBase()
+TMP_NAME ACardBase()
 {
  	// Set this actor to call Tick() every frame.  You can turn this off to improve performance if you don't need it.
 	PrimaryActorTick.bCanEverTick = true;
 
 }
 
+
 // Called when the game starts or when spawned
-void ACardBase::BeginPlay()
+virtual void TMP_NAME BeginPlay() override
 {
 	Super::BeginPlay();
 	
 }
 
 // Called every frame
-void ACardBase::Tick(float DeltaTime)
+virtual void TMP_NAME Tick(float DeltaTime) override
 {
 	Super::Tick(DeltaTime);
 

--- a/Source/TCG_Sample/Private/Deck.cpp
+++ b/Source/TCG_Sample/Private/Deck.cpp
@@ -2,10 +2,12 @@
 
 
 #include "Deck.h"
+#include "_imp.h"
 
+#define TMP_NAME ADeck::
 
 // Sets default values
-ADeck::ADeck()
+TMP_NAME ADeck()
 {
  	// Set this actor to call Tick() every frame.  You can turn this off to improve performance if you don't need it.
 	PrimaryActorTick.bCanEverTick = false;
@@ -13,25 +15,25 @@ ADeck::ADeck()
 }
 
 // Called when the game starts or when spawned
-void ADeck::BeginPlay()
+virtual void BeginPlay() override
 {
 	Super::BeginPlay();
 	
 }
 
 // Called every frame
-void ADeck::Tick(float DeltaTime)
+virtual void Tick(float DeltaTime) override
 {
 	Super::Tick(DeltaTime);
 
 }
 
-void ADeck::Shuffle()
+void TMP_NAME Shuffle()
 {
 	
 }
 
-void ADeck::Draw()
+void TMP_NAME Draw()
 {
 	if (Decklist.Num() > 0)
 	{
@@ -44,19 +46,19 @@ void ADeck::Draw()
 	}
 }
 
-void ADeck::ReturnCard(ACardBase* ReturnedCard)
+void TMP_NAME ReturnCard(ACardBase* ReturnedCard)
 {
 	int32 InsertIndex = FMath::RandRange(0, Decklist.Num());
 	Decklist.Insert(ReturnedCard, InsertIndex);
 }
 
-void ADeck::Redraw_Single(ACardBase* ReturnedCard)
+void TMP_NAME Redraw_Single(ACardBase* ReturnedCard)
 {
 	ReturnCard(ReturnedCard);
 	Draw();
 }
 
-TArray<ACardBase*> ADeck::Redraw_Multiple(TArray<ACardBase*> ReturnedCards)
+TArray<ACardBase*> TMP_NAME Redraw_Multiple(TArray<ACardBase*> ReturnedCards)
 {
 	return TArray<ACardBase*>();
 }

--- a/Source/TCG_Sample/Private/_imp.h
+++ b/Source/TCG_Sample/Private/_imp.h
@@ -1,0 +1,23 @@
+/**
+ * @file _imp.h
+ * @author ae2f
+ * @brief 
+ * @version 0.1
+ * @date 2025-02-20
+ * 
+ * @copyright Copyright (c) 2025
+ * 
+ * This file contains the keyword disabler, 
+ * in order to troubleshoot the copying the keyword from header directly.
+ * 
+ * A.K.A, convenience (abstraction)
+ * 
+ */
+
+/// @brief
+/// Since it is full implementing mode, we are disabling this keyword.
+#define override
+
+/// @brief
+/// Since it is full implementing mode, we are disabling this keyword.
+#define virtual

--- a/Source/TCG_Sample/Public/CardBase.h
+++ b/Source/TCG_Sample/Public/CardBase.h
@@ -6,6 +6,8 @@
 #include "GameFramework/Actor.h"
 #include "CardBase.generated.h"
 
+#define TMP_NAME
+
 UCLASS()
 class TCG_SAMPLE_API ACardBase : public AActor
 {
@@ -13,16 +15,15 @@ class TCG_SAMPLE_API ACardBase : public AActor
 	
 public:	
 	// Sets default values for this actor's properties
-	ACardBase();
+	TMP_NAME ACardBase();
 
 protected:
 	// Called when the game starts or when spawned
-	virtual void BeginPlay() override;
+	virtual void TMP_NAME BeginPlay() override;
 
 public:	
 	// Called every frame
-	virtual void Tick(float DeltaTime) override;
-
-	
-	
+	virtual void TMP_NAME Tick(float DeltaTime) override;
 };
+
+#undef TMP_NAME

--- a/Source/TCG_Sample/Public/Deck.h
+++ b/Source/TCG_Sample/Public/Deck.h
@@ -8,6 +8,8 @@
 
 class ACardBase;
 
+#define TMP_NAME
+
 UCLASS()
 class TCG_SAMPLE_API ADeck : public AActor
 {
@@ -19,11 +21,11 @@ public:
 
 protected:
 	// Called when the game starts or when spawned
-	virtual void BeginPlay() override;
+	virtual void TMP_NAME BeginPlay() override;
 
 public:	
 	// Called every frame
-	virtual void Tick(float DeltaTime) override;
+	virtual void TMP_NAME Tick(float DeltaTime) override;
 
 	
 protected:
@@ -31,17 +33,19 @@ protected:
 	TArray<ACardBase*> Decklist;
 
 	UFUNCTION(BlueprintCallable)
-	void Shuffle();
+	void TMP_NAME Shuffle();
 
 	UFUNCTION(BlueprintCallable)
-	void Draw();
+	void TMP_NAME Draw();
 
 	UFUNCTION(BlueprintCallable)
-	void ReturnCard(ACardBase* ReturnedCard);
+	void TMP_NAME ReturnCard(ACardBase* ReturnedCard);
 
 	UFUNCTION(BlueprintCallable)
-	void Redraw_Single(ACardBase* ReturnedCard);
+	void TMP_NAME Redraw_Single(ACardBase* ReturnedCard);
 
 	UFUNCTION(BlueprintCallable)
-	TArray<ACardBase*> Redraw_Multiple(TArray<ACardBase*> ReturnedCards);
+	TArray<ACardBase*> TMP_NAME Redraw_Multiple(TArray<ACardBase*> ReturnedCards);
 };
+
+#undef TMP_NAME


### PR DESCRIPTION
# What I am doing to this
With this pull request, I'd like to 

## #define TMP_NAME
> This is for convenience/safe.  
> It will help making the shape of declaration and definition of class methods.  
> Example would be following:

```cpp
#define TMP_NAME
class A {
    int TMP_NAMESPACE returns3(); // This is a function
};
#undef TMP_NAME

// hint for telling following functions are methods.
#define TMP_NAME A::

// By the same shape, returns3 will be automatically searched.
int TMP_NAME returns3() {
    return 3;
}
```
## Private/_imp.h
> This is for convenience/safe.  
> Including it will automatically disable the class method decorators which are not necessary for implementing methods,  
> preventing the miscompile from using them.

> Two keywords are disabled for now: 
- virtual
- override